### PR TITLE
Revert "Ignore broken group DMs"

### DIFF
--- a/ningen.go
+++ b/ningen.go
@@ -469,18 +469,6 @@ func (s *State) PrivateChannels() ([]discord.Channel, error) {
 		return nil, err
 	}
 
-	filtered := c[:0]
-	for _, ch := range c {
-		// This sometimes happens. It makes no sense for this to make it
-		// through!
-		if len(ch.DMRecipients) == 0 {
-			continue
-		}
-
-		filtered = append(filtered, ch)
-	}
-	c = filtered
-
 	sort.SliceStable(c, func(i, j int) bool {
 		return c[i].LastMessageID > c[j].LastMessageID
 	})


### PR DESCRIPTION
This reverts commit fe1b78f47f97f999a301549d17dcbd782f368aba.

This is due to the fact that Group DMs with no recipients means that they include the user, which is not included in the recipients list.

This may break another element, but that's unlikely and we will only find out later.

fixes #5 