### PR TITLE
relationship: store full Relationship, expose nickname and metadata

### DIFF
--- a/states/relationship/relationship.go
+++ b/states/relationship/relationship.go
@@ -12,22 +12,22 @@ import (
 
 type State struct {
 	mutex         sync.RWMutex
-	relationships map[discord.UserID]discord.RelationshipType
+	relationships map[discord.UserID]discord.Relationship
 }
 
 func NewState(store store.PresenceStore, r handlerrepo.AddHandler) *State {
 	rela := &State{
-		relationships: map[discord.UserID]discord.RelationshipType{},
+		relationships: map[discord.UserID]discord.Relationship{},
 	}
 
 	r.AddSyncHandler(func(r *gateway.ReadyEvent) {
 		rela.mutex.Lock()
 		defer rela.mutex.Unlock()
 
-		rela.relationships = make(map[discord.UserID]discord.RelationshipType, len(r.Relationships))
+		rela.relationships = make(map[discord.UserID]discord.Relationship, len(r.Relationships))
 
 		for _, rl := range r.Relationships {
-			rela.relationships[rl.UserID] = rl.Type
+			rela.relationships[rl.UserID] = rl
 
 			if rl.User.ID == rl.UserID {
 				// Update our local presence state.
@@ -46,7 +46,7 @@ func NewState(store store.PresenceStore, r handlerrepo.AddHandler) *State {
 		rela.mutex.Lock()
 		defer rela.mutex.Unlock()
 
-		rela.relationships[add.UserID] = add.Type
+		rela.relationships[add.UserID] = add.Relationship
 	})
 
 	r.AddSyncHandler(func(rem *gateway.RelationshipRemoveEvent) {
@@ -64,24 +64,42 @@ func (r *State) Each(fn func(discord.UserID, discord.RelationshipType) (stop boo
 	defer r.mutex.RUnlock()
 
 	for userID, rela := range r.relationships {
-		if fn(userID, rela) {
+		if fn(userID, rela.Type) {
 			return
 		}
 	}
 }
 
-// Relationship returns the relationship for the given user, or 0 if there is
-// none.
-func (r *State) Relationship(userID discord.UserID) discord.RelationshipType {
+// RelationshipType returns the relationship type for the given user, or 0 if
+// there is none.
+func (r *State) RelationshipType(userID discord.UserID) discord.RelationshipType {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
-	return r.relationships[userID]
+	return r.relationships[userID].Type
+}
+
+// Relationship returns the relationship type for the given user, or 0 if there
+// is none.
+//
+// Deprecated: Use RelationshipType instead.
+func (r *State) Relationship(userID discord.UserID) discord.RelationshipType {
+	return r.RelationshipType(userID)
+}
+
+// FullRelationship returns the full Relationship for the given user. The second
+// return value is false if no relationship exists.
+func (r *State) FullRelationship(userID discord.UserID) (discord.Relationship, bool) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	rel, ok := r.relationships[userID]
+	return rel, ok
 }
 
 // IsBlocked returns if the user is blocked.
 func (r *State) IsBlocked(userID discord.UserID) bool {
-	return r.Relationship(userID) == discord.BlockedRelationship
+	return r.RelationshipType(userID) == discord.BlockedRelationship
 }
 
 // BlockedUserIDs returns all blocked users.
@@ -91,7 +109,7 @@ func (r *State) BlockedUserIDs() []discord.UserID {
 
 	userIDs := make([]discord.UserID, 0, len(r.relationships))
 	for uID, relationship := range r.relationships {
-		if relationship != discord.BlockedRelationship {
+		if relationship.Type != discord.BlockedRelationship {
 			continue
 		}
 		userIDs = append(userIDs, uID)


### PR DESCRIPTION
## Summary
- Store the full `discord.Relationship` struct instead of just `RelationshipType`, preserving `Nickname`, `Since`, and `User` fields from the READY event
- Add `FullRelationship()` for accessing the complete struct
- Add `RelationshipType()` as a cleaner name for the existing `Relationship()` method (kept as deprecated alias)

## Motivation
The relationship state previously discarded the `Nickname` field, making it impossible for consumers to display friend nicknames (e.g. in DM channel lists) without reimplementing relationship tracking.

## Compatibility
No breaking changes to the public API. All existing methods (`Each`, `Relationship`, `IsBlocked`, `BlockedUserIDs`) retain their signatures and behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)